### PR TITLE
Add Amezmo Drupal settings

### DIFF
--- a/.amezmo/after.pull
+++ b/.amezmo/after.pull
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Make sure we fail our deployment if this hook fails.
+set -e;
+
+# More commands executed here.
+# Please see https://amezmo.xyz/docs/deployments/dependencies
+# for a full example
+
+# APPLICATION_ROOT is a default variable provided at hook execution time
+echo "Running this hook from ${APPLICATION_ROOT}";
+
+# Delete existing directory
+rmdir "${APPLICATION_ROOT}/web/sites/default/files"
+
+# Create it if it doesn't exist
+mkdir -p /webroot/storage/files
+
+# Create our symbolic link to point our public storage directory
+# to our persistent storage directory
+ln \
+    --symbolic \
+    --force \
+    --no-dereference \
+    /webroot/storage/files "${APPLICATION_ROOT}/web/sites/default";

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 .env
 .DS_Store
+.idea

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,11 @@
     "config": {
         "sort-packages": true
     },
+    "autoload": {
+        "files": [
+            "load.environment.php"
+        ]
+    },
     "extra": {
         "drupal-scaffold": {
             "locations": {

--- a/load.environment.php
+++ b/load.environment.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * This file is included very early. See autoload.files in composer.json and
+ * https://getcomposer.org/doc/04-schema.md#files
+ */
+
+use Dotenv\Dotenv;
+use Dotenv\Exception\InvalidPathException;
+
+/**
+ * Load any .env file. See /.env.example.
+ */
+$dotenv = Dotenv::createImmutable(__DIR__);
+try {
+  $dotenv->load();
+}
+catch (InvalidPathException $e) {
+  // Do nothing. Production environments rarely use .env files.
+}

--- a/web/sites/default/settings.amezmo.php
+++ b/web/sites/default/settings.amezmo.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @file
+ * Platform.sh settings.
+ */
+
+// Configure the database.
+if (isset($_ENV['APP_HOSTNAME'])) {
+  // TODO: FIND A WAY TO GET DB_HOST AND DB_USER
+  $databases['default']['default'] = [
+    'database' => $_ENV['DB_DATABASE'],
+    'driver' => 'mysql',
+    'host' => 'HOST',
+    'password' => $_ENV['DB_PASSWORD'],
+    'port' => $_ENV['DB_PORT'],
+    'prefix' => '',
+    'username' => 'USER'
+  ];
+
+  // Configure private and temporary file paths.
+  $settings['file_private_path'] = $_ENV['STORAGE_DIRECTORY'] . '/private';
+
+  // Configure the default PhpStorage and Twig template cache directories.
+  $settings['php_storage']['default']['directory'] = $settings['file_private_path'];
+  $settings['php_storage']['twig']['directory'] = $settings['file_private_path'];
+
+  $settings['file_chmod_directory'] = 2775;
+  $settings['file_chmod_file'] = 0664;
+
+  // Set the project-specific entropy value, used for generating one-time
+  // keys and such.
+  // TODO: FIND A WAY TO REPLACE THIS WITH APP_KEY
+  $settings['hash_salt'] = '';
+}
+
+// Set redis configuration.
+if (!empty($_ENV['REDIS_HOST'])) {
+  if (!\Drupal\Core\Installer\InstallerKernel::installationAttempted() && extension_loaded('redis') && class_exists('Drupal\redis\ClientFactory')) {
+    // Set Redis as the default backend for any cache bin not otherwise specified.
+    $settings['cache']['default'] = 'cache.backend.redis';
+    $settings['redis.connection']['host'] = $_ENV['REDIS_HOST'];
+    $settings['redis.connection']['port'] = $_ENV['REDIS_PORT'];
+
+    // Apply changes to the container configuration to better leverage Redis.
+    // This includes using Redis for the lock and flood control systems, as well
+    // as the cache tag checksum. Alternatively, copy the contents of that file
+    // to your project-specific services.yml file, modify as appropriate, and
+    // remove this line.
+    $settings['container_yamls'][] = 'modules/contrib/redis/example.services.yml';
+
+    // Allow the services to work before the Redis module itself is enabled.
+    $settings['container_yamls'][] = 'modules/contrib/redis/redis.services.yml';
+
+    // Manually add the classloader path, this is required for the container cache bin definition below
+    // and allows to use it without the redis module being enabled.
+    $class_loader->addPsr4('Drupal\\redis\\', 'modules/contrib/redis/src');
+
+    // Use redis for container cache.
+    // The container cache is used to load the container definition itself, and
+    // thus any configuration stored in the container itself is not available
+    // yet. These lines force the container cache to use Redis rather than the
+    // default SQL cache.
+    $settings['bootstrap_container_definition'] = [
+      'parameters' => [],
+      'services' => [
+        'redis.factory' => [
+          'class' => 'Drupal\redis\ClientFactory',
+        ],
+        'cache.backend.redis' => [
+          'class' => 'Drupal\redis\Cache\CacheBackendFactory',
+          'arguments' => ['@redis.factory', '@cache_tags_provider.container', '@serialization.phpserialize'],
+        ],
+        'cache.container' => [
+          'class' => '\Drupal\redis\Cache\PhpRedis',
+          'factory' => ['@cache.backend.redis', 'get'],
+          'arguments' => ['container'],
+        ],
+        'cache_tags_provider.container' => [
+          'class' => 'Drupal\redis\Cache\RedisCacheTagsChecksum',
+          'arguments' => ['@redis.factory'],
+        ],
+        'serialization.phpserialize' => [
+          'class' => 'Drupal\Component\Serialization\PhpSerialize',
+        ],
+      ],
+    ];
+  }
+}

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -773,28 +773,14 @@ $settings['migrate_node_migrate_type_classic'] = FALSE;
  *
  * Keep this code block at the end of this file to take full effect.
  */
-#
-# if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
-#   include $app_root . '/' . $site_path . '/settings.local.php';
-# }
 
+if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
+  include $app_root . '/' . $site_path . '/settings.local.php';
+}
 
-$settings['image_allow_insecure_derivatives'] = TRUE;
-$settings['file_chmod_directory'] = 2775;$
-$settings['file_chmod_file'] = 0664;
-
-(\Dotenv\Dotenv::createMutable($app_root . '/../'))->load();
-
-
-$databases['default']['default'] = array (
-  'database' => $_ENV['MYSQL_DATABASE'],
-  'username' => $_ENV['MYSQL_USER'],
-  'password' => $_ENV['MYSQL_PASSWORD'],
-  'prefix' => '',
-  'host' => $_ENV['MYSQL_HOSTNAME'],
-  'port' => '3306',
-  'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-  'driver' => 'mysql',
-);
+// Amezmo settings.
+if (file_exists($app_root . '/' . $site_path . '/settings.amezmo.php')) {
+  include $app_root . '/' . $site_path . '/settings.amezmo.php';
+}
 
 $settings['config_sync_directory'] = 'sites/default/files/config_HdeqQy5ZurGRrqdjembfRal0MuPmCf7Vqzl4ZT9jszESoelaKvjNoR0-RMKUP1vF-dMztkY11w/sync';


### PR DESCRIPTION
- Moves settings to individual file and looks for `APP_HOSTNAME` to setup
- Add after.pull to link `/web/sites/default/files` to `/webroot/storage/files` and make it if it doesn't exist
- Setup redis settings
- Autoload dotenv settings using composer

TODO:

- Figure out how to map mysql hostname and user to ENV variables
- Figure out how to get APP_KEY (or some encrypted key that can be used for salt)